### PR TITLE
Tweaks for osx-arm64 and perl 5.32.1

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,6 @@ There is an archived recipe that worked for Linux.
 To build the minimum package set required to run starcheck (and run/debug
 task_schedule) from OSX, the default package set of:
 
-    'perl-app-cpanminus',
     'perl-core-deps'
     'perl-ska-classic' # Includes Quat
 

--- a/build.py
+++ b/build.py
@@ -24,6 +24,8 @@ req_pkgs = [
 bonus_pkgs = [
     'xtime',
     'perl-extended-deps',
+    'perl-pdl',
+    'perl-astro-fits-cfitsio-simple',
     'perl-chandra-time',
     'perl-cxc-sysarch',
     'perl-app-env-ascds',
@@ -49,15 +51,14 @@ elif args.package == 'all':
 else:
     pkgs = [args.package]
 
+
 for pkg in pkgs:
     cmd = ["conda", "build", "-c", "conda-forge",
            "--use-local",
-           "--perl", "5.26.2", "--python", "3.10", "--croot", build_dir, pkg]
+           "--perl", "5.32.1", "--python", "3.11", "--numpy", "1.26.4", "--croot", build_dir, pkg]
 
     # Need conda-forge perl on Linux.  Would need to set up a local repo
     # to enforce just that package.  Adding conda-forge after defaults seems
     # to be working on Linux without taking that step (strict-channel-priority
     # does not seem to be an option in conda-build).
-    if system_name == 'Linux':
-        cmd.extend(["-c", "conda-forge"])
     subprocess.check_call(cmd)

--- a/build.py
+++ b/build.py
@@ -51,7 +51,6 @@ bonus_pkgs = [
 
 build_dir = os.path.join(args.build_root, "builds")
 
-system_name = platform.uname().system
 
 # If a package is requested, do that, else everything.
 if args.package is None:

--- a/perl-app-cpanminus/meta.yaml
+++ b/perl-app-cpanminus/meta.yaml
@@ -1,18 +1,16 @@
 package:
   name: perl-app-cpanminus
-  version: 1.7044
+  version: 1.7047
 
 source:
-  url: http://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7044.tar.gz
+  url: http://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7047.tar.gz
 
 build:
   number: 1
 
 requirements:
-  host:
-     - conda-forge::perl =5.26.2 # [linux]
-     - perl # [osx]
-
+  build:
+     - conda-forge::perl==5.32.1
   run:
-     - perl
+     - perl==5.32.1
 

--- a/perl-app-env-ascds/meta.yaml
+++ b/perl-app-env-ascds/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   host:
-    - conda-forge::perl =5.26.2 # [linux]
+    - conda-forge::perl =5.32.1 # [linux]
     - perl # [osx]
     - perl-extended-deps
     - perl-cxc-sysarch

--- a/perl-astro-fits-cfitsio-simple/build.sh
+++ b/perl-astro-fits-cfitsio-simple/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+export PERL_CPANM_HOME=${PREFIX}/tmp/cpanm
+export PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+
+CPANM="cpanm --from ${SRC_DIR} --mirror-index ${SRC_DIR}/modules/02packages.details.txt --self-contained "
+
+${CPANM} Astro::FITS::CFITSIO::Simple
+
+# Remove cpan work dirs
+rm -rf $PERL_CPANM_HOME
+
+
+
+
+
+
+
+
+
+
+
+

--- a/perl-astro-fits-cfitsio-simple/meta.yaml
+++ b/perl-astro-fits-cfitsio-simple/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: perl-astro-fits-cfitsio-simple
+  version: 0.20
+
+source:
+  url:  https://cxc.harvard.edu/mta/ASPECT/skare3-static-pkgs/cpan-core-0.4.tar.gz
+
+# On Linux, build seems to require conda-forge perl-5.26.2-h516909a_1006.tar.bz2,
+# 5.26.2 linux package from defaults seems broken as of 26-Jun-2020.
+requirements:
+#  build:
+#   - {{ compiler('c') }}
+#   - {{ compiler('cxx') }}
+  host:
+   - conda-forge::perl ==5.32.1
+   - conda-forge::perl-app-cpanminus
+   - perl-extended-deps ==0.4.0
+   - perl-io-tty
+   - perl-pdl
+  run:
+   - perl
+   - perl-app-cpanminus
+   - perl-io-tty
+   - perl-extended-deps ==0.4.0
+   - perl-pdl
+build:
+   number: 0
+
+
+
+
+
+
+

--- a/perl-chandra-time/meta.yaml
+++ b/perl-chandra-time/meta.yaml
@@ -15,7 +15,7 @@ build:
 requirements:
   host:
     - {{ compiler('cxx') }}
-    - conda-forge::perl =5.26.2 # [linux]
+    - conda-forge::perl =5.32.1 # [linux]
     - perl # [osx]
     - perl-extended-deps
     - xtime

--- a/perl-core-deps/build.sh
+++ b/perl-core-deps/build.sh
@@ -7,14 +7,10 @@ export EXPATLIBPATH=${PREFIX}/lib
 export EXPATINCPATH=${PREFIX}/include
 export LD=$CC
 
-# These modifications seemed necessary for the trickier package (Inline::Python) to build
-# but do not seem required now
-# if [ `uname` == Linux ]; then
-#     export LD=$CC
-# fi
-# if [ `uname` == Darwin ]; then
-#     export CFLAGS="${CFLAGS} -i sysroot ${CONDA_BUILD_SYSROOT}"
-# fi
+
+if [[ `uname` == Darwin  ]]; then
+    export CFLAGS="${CFLAGS} -i sysroot ${CONDA_BUILD_SYSROOT}"
+fi
 
 
 CPANM="cpanm --from ${SRC_DIR} --mirror-index ${SRC_DIR}/modules/02packages.details.txt --self-contained "
@@ -23,20 +19,14 @@ ${CPANM} Module::Build --notest
 ${CPANM} Date::Tie
 ${CPANM} Date::Parse --notest
 ${CPANM} Mail::Filter
+${CPANM} YAML::Tiny
+${CPANM} YAML
 ${CPANM} Pegex --installdeps
 ${CPANM} Pegex --notest
 ${CPANM} IO::All
 ${CPANM} IO::File
-${CPANM} Inline
-${CPANM} Inline::C --installdeps
-${CPANM} Inline::C --notest
-${CPANM} Schedule::Cron --installdeps
-${CPANM} Schedule::Cron --notest
-${CPANM} YAML::Tiny
-${CPANM} YAML
 ${CPANM} JSON::PP
 ${CPANM} JSON
-${CPANM} HTML::TableExtract
 ${CPANM} Expect
 ${CPANM} Expect::Simple
 ${CPANM} Config::General

--- a/perl-core-deps/conda_build_config.yaml
+++ b/perl-core-deps/conda_build_config.yaml
@@ -1,2 +1,0 @@
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.9.sdk        # [osx]

--- a/perl-core-deps/meta.yaml
+++ b/perl-core-deps/meta.yaml
@@ -1,33 +1,33 @@
 package:
   name: perl-core-deps
-  version: 0.3.1
+  version: 0.4.0
 
 source:
-  url:  https://cxc.harvard.edu/mta/ASPECT/skare3-static-pkgs/cpan-core-0.3.tar.gz
+  url:  https://cxc.harvard.edu/mta/ASPECT/skare3-static-pkgs/cpan-core-0.4.tar.gz
 
 # On Linux, build seems to require conda-forge perl-5.26.2-h516909a_1006.tar.bz2,
 # 5.26.2 linux package from defaults seems broken as of 26-Jun-2020.
 requirements:
-  host:
+  build:
    - {{ compiler('c') }}
    - {{ compiler('cxx') }}
-   - conda-forge::perl =5.26.2 # [linux]
-   - perl =5.26.2 # [osx]
+  host:
+   - conda-forge::perl ==5.32.1
    - perl-app-cpanminus
-   - perl-io-tty
+   - perl-io-tty ==1.16 # [osx and x86_64]
+   - perl-io-tty >=1.20 # [linux or arm64]
    - expat
    - pkg-config
    - yaml
-   - zlib
    - zip
   run:
-   - perl =5.26.2
+   - perl >=5.32
    - perl-app-cpanminus
-   - perl-io-tty
+   - perl-io-tty ==1.16 # [osx and x86_64]
+   - perl-io-tty >=1.20 # [linux or arm64]
    - expat
    - pkg-config
    - yaml
-   - zlib
    - zip
 build:
    number: 0

--- a/perl-cxc-sysarch/meta.yaml
+++ b/perl-cxc-sysarch/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   host:
-    - conda-forge::perl =5.26.2 # [linux]
+    - conda-forge::perl =5.32.1 # [linux]
     - perl # [osx]
     - perl-extended-deps
   run:

--- a/perl-dbd-sybase/meta.yaml
+++ b/perl-dbd-sybase/meta.yaml
@@ -1,14 +1,10 @@
 package:
   name: perl-dbd-sybase
-  version: !!str 1.15
+  version: !!str 1.24
 
 source:
-  url: file:///proj/sot/ska/pkgs/DBD-Sybase-1.15.tar.gz
-  #url: http://cpan.metacpan.org/authors/id/M/ME/MEWP/DBD-Sybase-1.15.tar.gz
-  md5: d76f09f9a25896fd879ef89a98748708
-  patches:
-   # List any patch files here
-    - config.patch
+  url: http://cpan.metacpan.org/authors/id/M/ME/MEWP/DBD-Sybase-1.24.tar.gz
+
 
 build:
   # If this is a new build for the same version, increment the build

--- a/perl-dbd-sybase/meta.yaml
+++ b/perl-dbd-sybase/meta.yaml
@@ -19,11 +19,11 @@ build:
 requirements:
   host:
     - {{ compiler('c') }}
-    - conda-forge::perl =5.26.2 # [linux]
+    - conda-forge::perl =5.32.1 # [linux]
     - perl # [osx]
     - perl-extended-deps
   run:
-    - perl =5.26.2
+    - perl =5.32.1
     - perl-extended-deps
 
 

--- a/perl-extended-deps/build.sh
+++ b/perl-extended-deps/build.sh
@@ -11,6 +11,13 @@ export LD=$CC
 
 CPANM="cpanm --from ${SRC_DIR} --mirror-index ${SRC_DIR}/modules/02packages.details.txt --self-contained "
 
+${CPANM} ExtUtils::MakeMaker::CPANfile
+${CPANM} Time::Out
+${CPANM} Schedule::Cron --installdeps
+${CPANM} Schedule::Cron --notest
+${CPANM} YAML
+${CPANM} HTML::TableExtract
+
 ${CPANM} File::Map
 ${CPANM} Module::Install
 ${CPANM} ExtUtils::PkgConfig
@@ -23,10 +30,7 @@ ${CPANM} IO::Tty --configure-timeout 120
 ${CPANM} Parse::RecDescent
 ${CPANM} Term::ReadLine::Perl --notest
 
-${CPANM} JSON::PP
-${CPANM} Inline
-${CPANM} Pegex --installdeps
-${CPANM} Pegex --notest
+${CPANM} Inline --notest
 ${CPANM} Inline::C --installdeps
 ${CPANM} Inline::C --notest
 ${CPANM} Test::Simple
@@ -37,7 +41,6 @@ ${CPANM} List::MoreUtils
 ${CPANM} Module::Compile
 ${CPANM} Test::Deep
 ${CPANM} Test::Exception
-${CPANM} Test::Warn
 
 ${CPANM} URI
 ${CPANM} Net::SSLeay
@@ -53,7 +56,7 @@ ${CPANM} Data::DumpXML
 ${CPANM} CGI
 
 ${CPANM} Term::ReadKey
-${CPANM} JSON
+
 ${CPANM} Carp::Clan
 ${CPANM} Bit::Vector
 ${CPANM} Tree::DAG_Node
@@ -65,7 +68,6 @@ ${CPANM} IO::File
 ${CPANM} Cwd
 ${CPANM} Readonly
 ${CPANM} File::chdir
-${CPANM} YAML::Tiny
 ${CPANM} Test::Simple
 ${CPANM} File::Slurp
 ${CPANM} IO::String
@@ -76,25 +78,19 @@ ${CPANM} IO::Compress::Zlib::Constants
 ${CPANM} Compress::Zlib
 ${CPANM} Archive::Zip --installdeps
 ${CPANM} Archive::Zip --notest
-${CPANM} Tie::IxHash
 ${CPANM} Clone
 ${CPANM} Class::MakeMethods --installdeps
 ${CPANM} Class::MakeMethods --notest
 
 ${CPANM} Class::Accessor
-${CPANM} Config::General
 ${CPANM} Hash::Merge
-${CPANM} YAML
-${CPANM} Expect
-${CPANM} Expect::Simple
 ${CPANM} Params::Validate
 ${CPANM} Env::Path
 ${CPANM} Time::JulianDay
 ${CPANM} Time::Local
 ${CPANM} File::MMagic
-${CPANM} Module::Build
 ${CPANM} version
-${CPANM} Sub::Uplevel
+
 ${CPANM} Test::Exception
 ${CPANM} Text::TabularDisplay
 ${CPANM} Text::Glob
@@ -106,17 +102,17 @@ ${CPANM} HTML::Table
 ${CPANM} IO::Stringy
 ${CPANM} Decision::Depends
 ${CPANM} Regexp::Common
-${CPANM} Date::Tie
 ${CPANM} Pod::Usage
 ${CPANM} Pod::Help
-${CPANM} Time::Out
+
+
 ${CPANM} Shell::GetEnv --notest
 ${CPANM} Module::Find
 ${CPANM} IPC::System::Simple
 ${CPANM} Capture::Tiny
 ${CPANM} Config::PFiles::Path
+
 ${CPANM} App::Env
-${CPANM} Schedule::Cron --notest
 ${CPANM} HTML::TreeBuilder
 ${CPANM} Text::RecordParser
 ${CPANM} POSIX::strptime
@@ -131,13 +127,13 @@ ${CPANM} DBI
 ${CPANM} DBD::SQLite
 ${CPANM} Astro::FITS::CFITSIO
 ${CPANM} Astro::FITS::Header
-${CPANM} PDL
+${CPANM} PDL --installdeps
 ${CPANM} Astro::FITS::CFITSIO::CheckStatus
-${CPANM} Astro::FITS::CFITSIO::Simple
+${CPANM} Class::MethodMaker
+${CPANM} Term::ProgressBar
 
 # Remove cpan work dirs
 rm -rf $PERL_CPANM_HOME
-
 
 
 

--- a/perl-extended-deps/meta.yaml
+++ b/perl-extended-deps/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: perl-extended-deps
-  version: 0.3.1
+  version: 0.4.0
 
 source:
-  url:  https://cxc.harvard.edu/mta/ASPECT/skare3-static-pkgs/cpan-core-0.3.tar.gz
+  url:  https://cxc.harvard.edu/mta/ASPECT/skare3-static-pkgs/cpan-core-0.4.tar.gz
 
 # On Linux, build seems to require conda-forge perl-5.26.2-h516909a_1006.tar.bz2,
 # 5.26.2 linux package from defaults seems broken as of 26-Jun-2020.
@@ -12,10 +12,10 @@ requirements:
    - {{ compiler('c') }}
    - {{ compiler('cxx') }}
   host:
-   - conda-forge::perl =5.26.2 # [linux]
-   - perl =5.26.2 # [osx]
+   - conda-forge::perl ==5.32.1
    - perl-app-cpanminus
-   - perl-core-deps
+   - perl-core-deps ==0.4.0
+   - perl-io-tty >=1.20
    - expat
    - pkg-config
    - libpng
@@ -25,13 +25,15 @@ requirements:
    - blas
    - mkl_fft
    - yaml
-   - zlib
+   - zlib ==1.2.13
+   - libzlib ==1.2.13
    - zip
    - cfitsio
   run:
    - perl
    - perl-app-cpanminus
-   - perl-core-deps
+   - perl-io-tty >=1.20
+   - perl-core-deps ==0.4.0
    - pkg-config
    - libpng
    - xtime
@@ -45,7 +47,7 @@ requirements:
    - zip
    - cfitsio
 build:
-   number: 0
+   number: 2
 
 
 

--- a/perl-io-tty/conda_build_config.yaml
+++ b/perl-io-tty/conda_build_config.yaml
@@ -1,2 +1,0 @@
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.9.sdk        # [osx]

--- a/perl-io-tty/meta.yaml
+++ b/perl-io-tty/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: perl-io-tty
-  version: !!str 1.12
+  version: !!str 1.20
 
 source:
-  url: https://cxc.harvard.edu/mta/ASPECT/skare3-static-pkgs/IO-Tty-1.12.tar.gz
+   url: https://cpan.metacpan.org/authors/id/T/TO/TODDR/IO-Tty-1.20.tar.gz
 
 build:
   # If this is a new build for the same version, increment the build
@@ -11,23 +11,23 @@ build:
   number: 0
 
 requirements:
-  host:
+  build:
    - {{ compiler('c') }}
    - {{ compiler('cxx') }}
-   - conda-forge::perl =5.26.2 # [linux]
-   - perl =5.26.2 # [osx]
-   - perl-app-cpanminus
+  host:
+   - conda-forge::perl ==5.32.1
+   - conda-forge::perl-app-cpanminus
    - expat
    - pkg-config
    - yaml
-   - zlib
+   - zlib ==1.2.13
    - zip
   run:
-   - perl =5.26.2
+   - perl
    - perl-app-cpanminus
    - expat
    - pkg-config
    - yaml
-   - zlib
+   - zlib ==1.2.13
    - zip
 

--- a/perl-pdl/build.sh
+++ b/perl-pdl/build.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
-# From https://github.com/conda/conda-build/issues/4392#issuecomment-1370281802
-if [[ $target_platform == osx-* ]]; then
-    for toolname in "otool" "install_name_tool"; do
-        tool=$(find "${BUILD_PREFIX}/bin/" -name "*apple*-$toolname")
-        mv "${tool}" "${tool}.bak"
-        ln -s "/Library/Developer/CommandLineTools/usr/bin/${toolname}" "$tool"
-    done
-fi
+
 
 # If it has Build.PL use that, otherwise use Makefile.PL
 if [ -f Build.PL ]; then

--- a/perl-pdl/meta.yaml
+++ b/perl-pdl/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: perl-pdl
+  version: 2.089
+
+source:
+  url: https://cpan.metacpan.org/authors/id/E/ET/ETJ/PDL-2.089.tar.gz
+  patches:
+    - no_gd.patch
+
+build:
+  number: 0
+
+requirements:
+  host:
+     - {{ compiler('c') }}
+     - {{ compiler('cxx') }}
+     - conda-forge::perl==5.32.1 
+     - perl-extended-deps
+  run:
+     - perl==5.32.1
+     - perl-extended-deps

--- a/perl-pdl/meta.yaml~
+++ b/perl-pdl/meta.yaml~
@@ -1,0 +1,22 @@
+package:
+  name: perl-pdl
+  version: 2.089
+
+source:
+  url: https://cpan.metacpan.org/authors/id/E/ET/ETJ/PDL-2.089.tar.gz
+  patches:
+    - no_gd.patch
+
+build:
+  number: 0
+
+requirements:
+  host:
+     - {{ compiler('c') }}
+     - {{ compiler('cxx') }}
+     - {{ compiler('fortran') }}
+     - conda-forge::perl==5.32.1 
+     - perl-extended-deps
+  run:
+     - perl==5.32.1
+     - perl-extended-deps

--- a/perl-pdl/no_gd.patch
+++ b/perl-pdl/no_gd.patch
@@ -1,0 +1,11 @@
+--- builds/perl-pdl_1716691567185/work/perldl.conf	2023-03-31 12:25:25.000000000 -0400
++++ perldl.conf	2024-05-25 22:57:44.962770388 -0400
+@@ -97,7 +97,7 @@
+ # false -> don't use
+ # true -> force use
+ 
+-        WITH_GD => undef,      # Leave it up to PDL to decide
++        WITH_GD => false,      # Leave it up to PDL to decide
+         GD_LIBS => undef,
+         GD_INC => undef,
+         GD_DEFINE => '',       # If anything needs to be defined.

--- a/perl-ska-agasc/meta.yaml
+++ b/perl-ska-agasc/meta.yaml
@@ -10,14 +10,16 @@ build:
 
 requirements:
   host:
-    - conda-forge::perl =5.26.2 # [linux]
+    - conda-forge::perl =5.32.1 # [linux]
     - perl # [osx]
     - perl-extended-deps
+    - perl-pdl
     - perl-chandra-time
     - perl-app-env-ascds
     - perl-ska-classic
   run:
     - perl
+    - perl-pdl
     - perl-extended-deps
     - perl-chandra-time
     - perl-app-env-ascds

--- a/perl-ska-classic/meta.yaml
+++ b/perl-ska-classic/meta.yaml
@@ -10,7 +10,6 @@ build:
 
 requirements:
   host:
-    - conda-forge::perl =5.26.2 # [linux]
-    - perl # [osx]
+    - conda-forge::perl =5.32.1
   run:
     - perl

--- a/perl-ska-convert/meta.yaml
+++ b/perl-ska-convert/meta.yaml
@@ -10,7 +10,7 @@ build:
 
 requirements:
   host:
-    - conda-forge::perl =5.26.2 # [linux]
+    - conda-forge::perl =5.32.1 # [linux]
     - perl # [osx]
     - perl-chandra-time
     - perl-ska-classic

--- a/perl-ska-web/meta.yaml
+++ b/perl-ska-web/meta.yaml
@@ -10,7 +10,7 @@ build:
 
 requirements:
   host:
-    - conda-forge::perl =5.26.2 # [linux]
+    - conda-forge::perl =5.32.1 # [linux]
     - perl # [osx]
     - perl-extended-deps
   run:

--- a/perl-tk/meta.yaml
+++ b/perl-tk/meta.yaml
@@ -13,7 +13,7 @@ requirements:
      - {{ compiler('c') }}
      - {{ compiler('cxx') }}
   host:
-     - conda-forge::perl =5.26.2 # [linux]
+     - conda-forge::perl ==5.32.1 # [linux]
      - perl # [osx]
      - xorg-libx11
      - xorg-libxft
@@ -25,7 +25,7 @@ requirements:
      - freetype
      - libpng
   run:
-     - perl
+     - perl ==5.32.1
      - xorg-libx11
      - xorg-libxft
      - xorg-xproto

--- a/xtime/meta.yaml
+++ b/xtime/meta.yaml
@@ -12,7 +12,8 @@ requirements:
     - {{ compiler('cxx') }}
 
 build:
-   number: 1
+   number: 2
+
 
 
 


### PR DESCRIPTION
Update and tweaks for osx-arm64 and perl 5.32.1

Packages from these builds are in https://icxc.cfa.harvard.edu/aspect/ska3-conda/perl 

A dev environment should install with:
```
conda install ska3-core-latest ska3-flight-latest ska3-perl-latest==2024.0 --override-channels -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/perl -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight -c conda-forge
```
